### PR TITLE
OSX works w/ gcc but it must be a REAL gcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ $ gcc -o test test.c mill.c -g -O0
 ```
 
 This is a proof of concept project that seems to work with x86-64, gcc
-and Linux. I have no idea about different environments. Also, the project
+and Linux. OSX requires a true gcc (for example, from MacPorts or Homebrew)
+and not clang. I have no idea about different environments. Also, the project
 is in very early stage of development and not suitable for actual usage.
 
 Mailing List


### PR DESCRIPTION
Confirmed that we now work on OS X 10.10.3. But clang is NOT supported due to gcc specific features... working on clang support.

Patch is MIT